### PR TITLE
add support for Python3.8 in constrained environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ APAPI is available on [PyPI](https://pypi.org/project/apapi/):
 ```console
 $ python -m pip install apapi
 ```
-APAPI supports Python 3.9+.
+APAPI supports Python 3.8+.
 
 ## More Info
 - [Official Anaplan APIs Postman Collection](https://www.postman.com/apiplan/workspace/official-anaplan-collection/overview)

--- a/apapi/alm.py
+++ b/apapi/alm.py
@@ -4,6 +4,8 @@ apapi.alm
 Child of Basic Connection class, responsible for
 Application Lifecycle Management API capabilities
 """
+from __future__ import annotations
+
 import json
 
 from requests import Response

--- a/apapi/audit.py
+++ b/apapi/audit.py
@@ -3,6 +3,8 @@ apapi.audit
 
 Child of Basic Connection class, responsible for Audit API capabilities
 """
+from __future__ import annotations
+
 import json
 
 from requests import Response

--- a/apapi/authentication.py
+++ b/apapi/authentication.py
@@ -3,6 +3,8 @@ apapi.authentication
 
 This module provides helper classes for authentication needs.
 """
+from __future__ import annotations
+
 import json
 import logging
 from abc import ABC, abstractmethod

--- a/apapi/basic_connection.py
+++ b/apapi/basic_connection.py
@@ -4,6 +4,7 @@ apapi.basic_connection
 This module provides a Basic Connection class,
 which should be used to connect to Anaplan APIs.
 """
+from __future__ import annotations
 
 import logging
 

--- a/apapi/bulk.py
+++ b/apapi/bulk.py
@@ -3,6 +3,8 @@ apapi.bulk
 
 Child of Basic Connection class, responsible for Bulk API capabilities
 """
+from __future__ import annotations
+
 import json
 
 from requests import Response

--- a/apapi/connection.py
+++ b/apapi/connection.py
@@ -3,6 +3,7 @@ apapi.connection
 
 This module provides Connection class, which contains all available API functions.
 """
+from __future__ import annotations
 
 from .alm import ALMConnection
 from .audit import AuditConnection

--- a/apapi/transactional.py
+++ b/apapi/transactional.py
@@ -3,6 +3,7 @@ apapi.transactional
 
 Child of Basic Connection class, responsible for Transactional API capabilities.
 """
+from __future__ import annotations
 
 import json
 from typing import Iterable

--- a/apapi/utils.py
+++ b/apapi/utils.py
@@ -4,6 +4,7 @@ apapi.utils
 This module provides utility classes, functions & constants that are used within APAPI,
 and might be useful for external consumption as well.
 """
+from __future__ import annotations
 
 import json
 from enum import Enum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.isort]
 profile="black"
-py_version=39
+py_version=38
 virtual_env="venv"
 skip_gitignore=true
 honor_noqa=true

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import find_packages, setup
 
-REQUIRES_PYTHON = "~=3.9"
+REQUIRES_PYTHON = "~=3.8"
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -52,6 +52,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
📌 [corresponding issue](https://github.com/DLZaan/apapi/issues/15#issue-2090435799)
We want to use Anaplan API on constrained environments like Composer that only provision Airflow images shipped with Python 3.8
